### PR TITLE
Change dark-default to dark-theme

### DIFF
--- a/repo-card.js
+++ b/repo-card.js
@@ -22,7 +22,7 @@ window.addEventListener('DOMContentLoaded', async function() {
       color: '#586069',
       linkColor: '#0366d6',
     },
-    'dark-default': {
+    'dark-theme': {
       background: 'rgb(13, 17, 23)',
       borderColor: 'rgb(48, 54, 61)',
       color: 'rgb(139, 148, 158)',


### PR DESCRIPTION
Currently in README.md there's this example:

```html
<!-- NEW: for dark theme just set data-theme attribute -->
<div class="repo-card" data-repo="username/repository" data-theme="dark-theme"></div>
```

However, this doesn't work because in repo-card.js you're looking for the 'dark-default' attribute, which doesn't exist 🙂 